### PR TITLE
Add support for broadcast messages & allow subscriptions without authentication

### DIFF
--- a/models/subscription.py
+++ b/models/subscription.py
@@ -1,17 +1,14 @@
 from datetime import datetime
 from dependencies.database import Base
 from sqlalchemy import Column, Integer, String, DateTime, JSON
+from sqlalchemy.types import JSON as SQLAlchemyJSON
 from models import activity
+
 
 class Subscription(Base):
     __tablename__ = "webpush_notifications_subscriptions"
-    
+
     id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(String, nullable=False)
-    subscription = Column(JSON, nullable=False)
+    user_id = Column(String, nullable=True)  # Allow anonymous subscriptions
+    subscription = Column(SQLAlchemyJSON, nullable=False)
     created_at = Column(DateTime, default=datetime.utcnow)
-
-    
-
-
-

--- a/router/subscription.py
+++ b/router/subscription.py
@@ -1,19 +1,58 @@
-from utils.api import Router, Depends
+from utils.api import Router, Depends, HTTPException
 from dependencies.auth import get_current_user
 from sqlalchemy.orm import Session
 from dependencies.database import get_db
 from ..models.subscription import Subscription
-from ..schemas import SubscriptionCreate
+from ..schemas import SubscriptionCreate, WebPushSubscription
+import logging
 
+logger = logging.getLogger("coffeebreak.webpush")
 router = Router()
 
-@router.post("/")
-def subscribe(subscription: SubscriptionCreate, userdata: dict = Depends(get_current_user), db: Session = Depends(get_db)):
-    new_subscription = Subscription(
-        user_id=userdata["sub"],
-        subscription=subscription.subscription
-    )
-    db.add(new_subscription)
-    db.commit()
-    db.refresh(new_subscription)
-    return new_subscription
+
+@router.post("/", response_model=WebPushSubscription)
+async def subscribe(
+    subscription: SubscriptionCreate,
+    db: Session = Depends(get_db),
+    user: dict | None = Depends(lambda: get_current_user(force_auth=False))
+):
+    """Create a new subscription. Works for both authenticated and anonymous users."""
+    try:
+        subscription_dict = subscription.subscription.model_dump()
+
+        # Validate subscription data
+        if not subscription_dict.get("endpoint") or not subscription_dict.get("keys"):
+            raise HTTPException(
+                status_code=400,
+                detail="Invalid subscription format. Must include endpoint and keys."
+            )
+
+        new_subscription = Subscription(
+            user_id=user.get("sub") if user else None,
+            subscription=subscription_dict
+        )
+
+        try:
+            db.add(new_subscription)
+            db.commit()
+            db.refresh(new_subscription)
+            logger.info(
+                f"New subscription created for user: {new_subscription.user_id}")
+            return new_subscription
+        except Exception as db_error:
+            db.rollback()
+            logger.error(
+                f"Database error while creating subscription: {str(db_error)}")
+            raise HTTPException(
+                status_code=500,
+                detail="Failed to save subscription. Please try again."
+            )
+
+    except HTTPException as http_error:
+        raise http_error
+    except Exception as e:
+        logger.error(f"Unexpected error in subscribe endpoint: {str(e)}")
+        raise HTTPException(
+            status_code=500,
+            detail="An unexpected error occurred. Please try again later."
+        )

--- a/schemas.py
+++ b/schemas.py
@@ -1,8 +1,45 @@
-from pydantic import BaseModel
-from typing import Dict
+from pydantic import BaseModel, Field
+from typing import Dict, Optional
+
+
+class PushSubscription(BaseModel):
+    endpoint: str
+    keys: Dict[str, str]
+    expirationTime: Optional[int] = None
+
+    class Config:
+        from_attributes = True
+        json_schema_extra = {
+            "example": {
+                "endpoint": "https://updates.push.services.mozilla.com/wpush/v2/...",
+                "keys": {
+                    "auth": "auth_key",
+                    "p256dh": "public_key"
+                },
+                "expirationTime": None
+            }
+        }
+
 
 class SubscriptionCreate(BaseModel):
-    subscription: Dict
+    subscription: PushSubscription
+
+    class Config:
+        from_attributes = True
+
+
+class WebPushSubscription(BaseModel):
+    subscription: PushSubscription
+    user_id: Optional[str] = None  # Optional for anonymous subscriptions
+
+    class Config:
+        from_attributes = True
+
+
+class WebPushSubscriptionResponse(BaseModel):
+    id: str
+    subscription: PushSubscription
+    user_id: Optional[str] = None
 
     class Config:
         from_attributes = True


### PR DESCRIPTION
This PR adds allows users to subscribe notifications without requiring authentication. It also adds support for broadcast web push notifications.