### PR TITLE
Add plugin identifier

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -5,6 +5,7 @@ import logging
 
 logger = logging.getLogger("coffeebreak.webpush-notifications")
 
+IDENTIFIER = "webpush-notifications"
 NAME = "Web Push Notifications Plugin"
 DESCRIPTION = "A plugin for sending web push notifications"
 


### PR DESCRIPTION
Fix missing plugin identifier that was causing plugin registration issues, ensuring proper system integration and recognition of the WebPush notifications plugin.

**Related Jira Ticket:** SCRUM-341