### PR TITLE
feat: add pyproject.toml manifest and simplify plugin init

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -5,21 +5,16 @@ import logging
 
 logger = logging.getLogger("coffeebreak.webpush-notifications")
 
-IDENTIFIER = "webpush-notifications"
-NAME = "Web Push Notifications Plugin"
-DESCRIPTION = "A plugin for sending web push notifications"
 
-async def register_plugin():
+async def REGISTER():
     message_bus = MessageBus()
     message_bus.register_message_handler("webpush", send_webpush)
     message_bus.register_message_handler("in-app", send_webpush)
     logger.info("Web Push Notifications Plugin registered")
 
-async def unregister_plugin():
+
+async def UNREGISTER():
     message_bus = MessageBus()
     message_bus.unregister_message_handler("webpush", send_webpush)
     message_bus.unregister_message_handler("in-app", send_webpush)
     logger.info("Web Push Notifications Plugin unregistered")
-
-REGISTER = register_plugin
-UNREGISTER = unregister_plugin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.coffeebreak]
+identifier = "webpush-notifications"
+name = "Web Push Notifications Plugin"
+description = "A plugin for sending web push notifications"


### PR DESCRIPTION
## Summary
- Added `pyproject.toml` with `[tool.coffeebreak]` manifest for plugin metadata
- Simplified `__init__.py` — removed metadata constants and REGISTER/UNREGISTER aliases
- Metadata is now handled by the core automatically via the manifest